### PR TITLE
Julius Alsen 

### DIFF
--- a/js/data/protokolle.json
+++ b/js/data/protokolle.json
@@ -15101,7 +15101,7 @@
     "id": 1068,
     "band": 27,
     "sn": 1908.0,
-    "seite": 190,
+    "seite": 197,
     "sok": true,
     "datum": "1908-07-22",
     "dok": true,

--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -142,14 +142,15 @@
     "last": "Almstedt?"
   },
   "647": {
-    "name": "J? Als?en?",
+    "name": "Julius Alsen",
     "ids_to_signatures": {
       "1005": [
-        "J[?] Als[?]en?"
+        "J[ulius] Alsen?"
       ]
     },
-    "first": "J?",
-    "last": "Als?en?"
+    "first": "Julius",
+    "last": "Alsen?",
+    "source": "AV 1906.0 S. 38"
   },
   "656": {
     "name": "Julius Amelung",

--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -182,14 +182,15 @@
     "last": "Ameseder"
   },
   "679": {
-    "name": "A v Amsel?",
+    "name": "August Ansel",
     "ids_to_signatures": {
       "1068": [
-        "A[]. v Amsel?"
+        "A. Ansel"
       ]
     },
-    "first": "A Amsel?",
-    "last": "Amsel?"
+    "first": "August",
+    "last": "Ansel",
+    "source": "AV 1908.0 S. 39"
   },
   "178": {
     "name": "Albert Andrae",


### PR DESCRIPTION
aus Nieby, Schleswig-Holstein. Quelle "AV" steht für "Amtliches Verzeichnis des Personals und der Studierenden der Königlichen Georg-Augusts-Universität zu Göttingen" (GDZ)