### PR TITLE
name mismatch. Der Name findet sich überall mit Doppel-a (auch dän. w…

### DIFF
--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -2390,13 +2390,13 @@
     "last": "Hecht?"
   },
   "499": {
-    "name": "Poul Heegård Heegaard",
+    "name": "Poul Heegaard",
     "ids_to_signatures": {
       "585": [
         "Poul Heegård [Heegaard]"
       ]
     },
-    "first": "Poul Heegaard",
+    "first": "Poul",
     "last": "Heegaard"
   },
   "314": {


### PR DESCRIPTION
…iki usw.)