### PR TITLE
Nicolaus Chatzidakis

### DIFF
--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -2748,14 +2748,19 @@
     "last": "Hort"
   },
   "163": {
-    "name": "Hozzickakes??",
+    "name": "Nicolaus [Nikolaos] Chatzidakis [Hatzidakis]",
     "ids_to_signatures": {
       "717": [
-        "[Hozzickakes??]"
+        "[Hazzidakis [Chatzidakis]]"
       ]
     },
-    "first": "",
-    "last": "Hozzickakes??"
+    "first": "Nicolaus [Nikolaos]",
+    "last": "Chatzidakis [Hatzdakis]",
+    "source": [
+      "AV 1998.0 S. 39",
+      "KT foll. 187"
+    ],
+    "origin": "Athen"
   },
   "536": {
     "name": "G? Huber?",


### PR DESCRIPTION
Im Amtlichen Verz. unter "Nicolaus Chatzidakis", in Kleins Verzeichnis "Chatzidakis", wikipedia "Nikolaos Hatzidakis", Protokolle "Hazzidakis". Sohn des "John Hazzidakis" für den es auch versch. Transliterationen gibt