### PR TITLE
2 Liebmanns

### DIFF
--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -4038,13 +4038,13 @@
     "last": "Lebedewa"
   },
   "491": {
-    "name": "H?einrich Liebmann",
+    "name": "Karl Otto Heinrich Liebmann",
     "ids_to_signatures": {
       "664": [
-        "H?[einrich] Liebmann"
+        "H[einrich] Liebmann"
       ]
     },
-    "first": "H?einrich",
+    "first": "Karl Otto Heinrich",
     "last": "Liebmann"
   },
   "630": {
@@ -4070,7 +4070,12 @@
       ]
     },
     "first": "Heinrich",
-    "last": "Liebmann"
+    "last": "Liebmann",
+    "source": [
+      "AV 1896.5 S. 47"
+      "AV 1897.0 S. 49"
+    ],
+    "origin": "Jena"
   },
   "854": {
     "name": "Ferdinand von Lindemann",

--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -4072,7 +4072,7 @@
     "first": "Heinrich",
     "last": "Liebmann",
     "source": [
-      "AV 1896.5 S. 47"
+      "AV 1896.5 S. 47",
       "AV 1897.0 S. 49"
     ],
     "origin": "Jena"


### PR DESCRIPTION
(Karl Otto) Heinrich Liebmann (*1874 in Straßburg, Vater aus Jena), prom. 1895, war 1897 und 1898 Kleins Assistent. Das müsste der "Dr. Liebmann" (ID 491) sein.  (Handschrift: Sütterlin).
Gleichzeitig ist für 1896-1897 ein Student H. Liebmann ohne Doktortitel aus Jena eingetragen, der im letzten Vortrag mit Heinrich Liebmann (Handschrift: "lateinisch") unterschrieben hat. Wegen unterschiedl. Handschriften und Unterschrift (einmal mit "Dr" und sonst ohne) würde ich tippen dass es versch. Leute waren und der erstere der Assistent. Aber sicher bin  ich nicht.