### PR TITLE
Wieghardt.

### DIFF
--- a/js/data/protokolle.json
+++ b/js/data/protokolle.json
@@ -12211,7 +12211,8 @@
     "titel": "Einleitender Vortrag von Herrn Geh. Rat [Felix] Klein.\\newline am 29. April",
     "ktitel": "",
     "speaker": [
-      1158
+      940,
+      1050
     ]
   },
   {
@@ -12400,7 +12401,8 @@
     "titel": "Verschiedene Ausführungen von Herrn Geh-Rat [Felix] Klein",
     "ktitel": "",
     "speaker": [
-      1158
+      940,
+      1050
     ]
   },
   {
@@ -12414,7 +12416,8 @@
     "titel": "Verschiedene Ausführungen von Herrn Geh-Rat [Felix] Klein",
     "ktitel": "",
     "speaker": [
-      1158
+      940,
+      1050
     ]
   },
   {
@@ -12527,7 +12530,8 @@
     "titel": "Einleitender Vortrag von Herrn Geh.-Rat [Felix] Klein.",
     "ktitel": "",
     "speaker": [
-      972
+      940,
+      1050
     ]
   },
   {
@@ -12642,7 +12646,8 @@
     "titel": "Bemerkungen von Herrn Geh.-Rat [Felix] Klein\\newline zum 3. -- 8. Vortrage.",
     "ktitel": "",
     "speaker": [
-      505
+      940,
+      1050
     ]
   },
   {
@@ -12727,7 +12732,8 @@
     "titel": "Einige Bemerkungen von Herrn Geh-Rat [Felix] Klein\\newline zum\\newline Wassersprung.",
     "ktitel": "",
     "speaker": [
-      505
+      940,
+      1050
     ]
   },
   {
@@ -14493,7 +14499,8 @@
     "titel": "",
     "ktitel": "Numerische Bestimmung der durch das Oszillationstheorem definierten Parameter",
     "speaker": [
-      283
+      283,
+      940
     ]
   },
   {

--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -2310,6 +2310,12 @@
       "580": "[Felix] Klein",
       "581": "[Felix] Klein",
       "775": "[Felix Klein]",
+      "863": "[Felix Klein, aufgeschrieben von] K[arl]. Wieghardt",
+      "876": "[Felix Klein, aufgeschrieben von] K[arl]. Wieghardt",
+      "877": "[Felix Klein, aufgeschrieben von] K[arl]. Wieghardt",
+      "885": "[Felix Klein, aufgeschrieben von], Dr. K[arl] Wieghardt",
+      "893": "[Felix Klein, aufgeschrieben von] Dr. K[arl] Wieghardt",
+      "899": "[Felix Klein, aufgeschrieben von] Dr. K[arl] Wieghardt",
       "903": "[Felix] Klein",
       "909": "[Felix] Klein",
       "919": "[Felix] Klein",
@@ -2335,6 +2341,7 @@
       "1006": "[Felix Klein], [Franz Graf]",
       "1008": "[Felix Klein], [Franz Graf]",
       "1015": "[Felix] Klein",
+      "1024": "[1. Teil von Felix Klein, aufgeschrieben von] H[ermann] Rothe, [2. Teil von] H[ermann] Rothe",
       "1026": "[Felix Klein]",
       "1027": "[Felix Klein]",
       "1028": "[Felix Klein]",
@@ -4289,31 +4296,17 @@
     "first": "TODO Felix Klein Dr. Heinrich Liebmann",
     "last": "TODO Felix Klein Dr. Heinrich Liebmann"
   },
-  "972": {
-    "name": "Felix Klein, Dr. Karl Wieghardt.",
-    "ids_to_signatures": {
-      "885": "[Felix Klein], Dr. K[arl] Wieghardt."
-    },
-    "first": "TODO Felix Klein, Dr. Karl Wieghardt.",
-    "last": "TODO Felix Klein, Dr. Karl Wieghardt"
-  },
   "283": {
-    "name": "Felix Klein, Herrmann? Rothe, ",
+    "name": "Herrmann Rothe",
     "ids_to_signatures": {
-      "1024": "[Felix Klein], H[errmann?] Rothe,"
+      "1024": "[1. Teil von Felix Klein, aufgeschrieben von] H[ermann] Rothe, [2. Teil von] H[ermann] Rothe"
     },
-    "first": "TODO Felix Klein, Herrmann? Rothe, ",
-    "last": "TODO Felix Klein, Herrmann? Rothe,"
-  },
-  "1158": {
-    "name": "Felix Klein, Karl Wieghardt",
-    "ids_to_signatures": {
-      "863": "[Felix Klein], K[arl]. Wieghardt",
-      "876": "[Felix Klein], K[arl] Wieghardt",
-      "877": "[Felix Klein], K[arl] Wieghardt"
+    "first": "Herrmann",
+    "last": "Rothe",
+    "sources": {
+      "AV 1906.5 S.69": "https://gdz.sub.uni-goettingen.de/id/PPN658958380_1906_1907_WS?tify=%7B%22pages%22%3A%5B69%5D%7D"
     },
-    "first": "TODO Felix Klein, Karl Wieghardt",
-    "last": "TODO Felix Klein, Karl Wieghardt"
+    "origin": "Wien"
   },
   "428": {
     "name": "Felix KleinHandschrift von Osgood",
@@ -4355,15 +4348,6 @@
     },
     "first": "TODOFriedrich Kuhse?, unleserlich?  Wieck|hmann",
     "last": "TODOFriedrich Kuhse?, unleserlich?  Wieck|hmann"
-  },
-  "505": {
-    "name": "Felix Klein, Dr. Karl Wieghardt",
-    "ids_to_signatures": {
-      "893": "[Felix Klein], Dr. K[arl] Wieghardt",
-      "899": "[Felix Klein], Dr. K[arl]. Wieghardt"
-    },
-    "first": "TODOFelix/Karl",
-    "last": "TODOKlein/Wieghardt"
   },
   "686": {
     "name": "Ludwig Prandt Felix Klein",
@@ -4823,7 +4807,13 @@
     "ids_to_signatures": {
       "786": "Karl Wieghardt",
       "865": "K[arl]. Wieghardt",
-      "871": "K[arl] Wieghardt"
+      "871": "K[arl] Wieghardt",
+      "863": "[Felix Klein, aufgeschrieben von] K[arl]. Wieghardt",
+      "876": "[Felix Klein, aufgeschrieben von] K[arl]. Wieghardt",
+      "877": "[Felix Klein, aufgeschrieben von] K[arl]. Wieghardt",
+      "885": "[Felix Klein, aufgeschrieben von] Dr. K[arl] Wieghardt",
+      "893": "[Felix Klein, aufgeschrieben von] Dr. K[arl] Wieghardt",
+      "899": "[Felix Klein, aufgeschrieben von] Dr. K[arl] Wieghardt"
     },
     "first": "Karl",
     "last": "Wieghardt"


### PR DESCRIPTION
Ich habe von Wieghardt aufgeschriebene Vorträge von Klein jetzt beiden zugeordnet und würde das auch bei allen so machen wenn es dir recht ist. Grund ist, dass es doch recht schwierig ist im Einzelfall zu unterscheiden wer jetzt wie viel Anteil am Gesamtergebnis hat, sinnvoller scheint es daher immer beide aufzuführen