### PR TITLE
temporarily use http for sites in Göttingen

### DIFF
--- a/js/klein.js
+++ b/js/klein.js
@@ -507,8 +507,8 @@ $(document).ready(function () {
 			var band = e.attr("band")
 			var teil = e.attr("teil")
 			var seite = e.attr("seite")
-			var bildurl = 'https:\/\/www.uni-math.gwdg.de\/aufzeichnungen\/klein-scans\/klein\/' + prefix + '/V' + band + teil + '-p' + pad(seite) + '_low.jpg'
-			var longprefix = 'https:\/\/www.uni-math.gwdg.de\/aufzeichnungen\/klein-scans\/klein\/' + prefix + '/V' + band + teil + '-p'
+			var bildurl = 'http:\/\/www.uni-math.gwdg.de\/aufzeichnungen\/klein-scans\/klein\/' + prefix + '/V' + band + teil + '-p' + pad(seite) + '_low.jpg'
+			var longprefix = 'http:\/\/www.uni-math.gwdg.de\/aufzeichnungen\/klein-scans\/klein\/' + prefix + '/V' + band + teil + '-p'
 			hideprev(seite);
 
 			processbild = "ico/proc.gif";


### PR DESCRIPTION
because https is currently not reachable.