### PR TITLE
"dritter" nicht "dritte"

### DIFF
--- a/js/data/protokolle.json
+++ b/js/data/protokolle.json
@@ -3258,7 +3258,7 @@
     "sok": true,
     "datum": "1879-03-01",
     "dok": true,
-    "titel": "Über die $27$ Geraden einer Fläche dritte Ordnung.",
+    "titel": "Über die $27$ Geraden einer Fläche dritter Ordnung.",
     "ktitel": "",
     "speaker": [
       55


### PR DESCRIPTION
Renate Tobies schreibt:

eine tschechische Kollegin hat mir gerade ihren Beitrag fuer unsere beabsichtigte MFO-Monographie geschickt und einen Vortragstitel abgeschrieben, bei dem tatsaechlich ein r fehlt (ist innerhlab der Original-Seite aber richtig):

Kraus Ludwig (ist ein Tscheche):
Ludvík Kraus ((1857–1884)

Über die 27 Geraden einer Fläche dritter Ordnung ( Band 1.2, p. 41),