### PR TITLE
Hermann Trommsdorff

### DIFF
--- a/js/data/teilnehmer.json
+++ b/js/data/teilnehmer.json
@@ -4941,11 +4941,11 @@
     "last": "Townsend"
   },
   "849": {
-    "name": "H? Trommsdorff",
+    "name": "Hermann Trommsdorff",
     "ids_to_signatures": {
-      "1188": "H[?]. Trommsdorff"
+      "1188": "H[ermann]. Trommsdorff"
     },
-    "first": "H?",
+    "first": "Hermann",
     "last": "Trommsdorff"
   },
   "305": {


### PR DESCRIPTION
Renate Tobies:

*Trommsdorff, Hermann 1874–1957, Dr. Lehrer, DMV:

* heisst, er spendete fuer das Liebermann-Klein-Portraet...